### PR TITLE
Add incomplete test using Mocha framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
@@ -106,6 +112,20 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -115,6 +135,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -161,6 +187,15 @@
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
         "ms": "^2.1.1"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "delayed-stream": {
@@ -257,6 +292,12 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
@@ -419,6 +460,12 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -644,6 +691,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "npm": "6.9.0"
   },
   "scripts": {
-    "start": "node src/main/Main.js"
+    "start": "node src/main/Main.js",
+    "test": "mocha"
   },
   "dependencies": {
     "blessed": "^0.1.81",
@@ -15,5 +16,8 @@
     "node-binance-api": "^0.9.0",
     "pino": "^5.11.1",
     "pino-pretty": "^2.5.0"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,13 @@ All logs are stored in the `/logs` directory. The log level is set via the `LOG.
 * **performance.log** - Data about performance and speed
 * **execution.log** - Market interactions and profits
 
+## Running the tests
+This project uses the `mocha` testing framework and the tests can be run by running:
+
+    ```
+    npm test
+    ```
+
 
 ## Authors
 * **[Brandon Mino](https://github.com/bmino)** - *Project Lead*

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,12 @@
+var assert = require('chai').assert;
+var calculationNode = require('../src/main/CalculationNode');
+
+describe('CalculationNode', function() {
+  describe('calculateDustless', function() {
+    context('with an integer', function() {
+      it('should return an integer', function() {
+        assert.equal(calculationNode.calculateDustless('SOMETICKER', 1), 1)
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds the Mocha framework for tests and adds an incomplete initial test.
The test is written in the [BDD][1] format.

You can run the tests using `npm test`.

[1]: https://www.agilealliance.org/glossary/bdd/